### PR TITLE
add neo4j:console task to start Neo4j server in foreground

### DIFF
--- a/lib/neo4j/rake_tasks/neo4j_server.rake
+++ b/lib/neo4j/rake_tasks/neo4j_server.rake
@@ -63,6 +63,15 @@ namespace :neo4j do
     server_manager.start(false)
   end
 
+  desc 'Start the Neo4j Server in the foreground'
+  task :console, :environment do |_, args|
+    args.with_defaults(environment: :development)
+
+    puts "Starting Neo4j (foreground) in #{args[:environment]}..."
+    server_manager = server_manager(args[:environment])
+    server_manager.console
+  end
+
   desc 'Configure Server, e.g. rake neo4j:config[development,8888]'
   task :config, :environment, :port do |_, args|
     args.with_defaults(environment: :development)

--- a/lib/neo4j/rake_tasks/server_manager.rb
+++ b/lib/neo4j/rake_tasks/server_manager.rb
@@ -38,6 +38,10 @@ module Neo4j
         system_or_fail(neo4j_command_path(:stop))
       end
 
+      def console
+        system_or_fail(neo4j_command_path(:console))
+      end
+
       def info
         validate_is_system_admin!
 


### PR DESCRIPTION
It can be useful to start Neo4j server in the foreground, for example when developing using a foreman Procfile.  

This pull request add a neo4j:console task that starts the server in the foreground.