### PR TITLE
Add 'for' to :info task description

### DIFF
--- a/lib/neo4j/rake_tasks/neo4j_server.rake
+++ b/lib/neo4j/rake_tasks/neo4j_server.rake
@@ -101,7 +101,7 @@ namespace :neo4j do
     server_manager.stop
   end
 
-  desc 'Get info the Neo4j Server'
+  desc 'Get info for the Neo4j Server'
   task :info, :environment do |_, args|
     args.with_defaults(environment: :development)
 


### PR DESCRIPTION
Went with 'for' rather than 'on' or 'about' to match the output.