### PR TITLE
Fix property-changing regexp

### DIFF
--- a/lib/neo4j/rake_tasks/server_manager.rb
+++ b/lib/neo4j/rake_tasks/server_manager.rb
@@ -122,7 +122,7 @@ module Neo4j
 
         File.open(property_configuration_path, 'w') do |file|
           result = properties.inject(contents) do |r, (property, value)|
-            r.gsub(/#{property}\s*=\s*(\w+)/, "#{property}=#{value}")
+            r.gsub(/#{property}\s*=\s*(.+)/, "#{property}=#{value}")
           end
           file << result
         end


### PR DESCRIPTION
Match any characters after the property's equal sign and
(optionally) whitespaces.

The previous regex matched only 'word' characters, which does not
include '-'.

Fixes #20