### PR TITLE
Avoid warning message when bundle install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-group 'development', 'test' do
-  gem 'pry'
-end
-
 group 'test' do
   gem 'coveralls', require: false
   gem 'simplecov-html', require: false


### PR DESCRIPTION
This pull changes avoid the following messages.
```
Your Gemfile lists the gem pry (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
```

Pings:
@cheerfulstoic
@subvertallchris