### PR TITLE
allow custom download url

### DIFF
--- a/lib/neo4j/rake_tasks/starnix_server_manager.rb
+++ b/lib/neo4j/rake_tasks/starnix_server_manager.rb
@@ -23,7 +23,8 @@ module Neo4j
       end
 
       def download_url(version)
-        "http://dist.neo4j.org/neo4j-#{version}-unix.tar.gz"
+        ENV['NEO4J_DIST'] && ENV['NEO4J_DIST'].gsub('version', version) ||
+          "http://dist.neo4j.org/neo4j-#{version}-unix.tar.gz"
       end
     end
   end

--- a/lib/neo4j/rake_tasks/starnix_server_manager.rb
+++ b/lib/neo4j/rake_tasks/starnix_server_manager.rb
@@ -23,8 +23,7 @@ module Neo4j
       end
 
       def download_url(version)
-        ENV['NEO4J_DIST'] && ENV['NEO4J_DIST'].gsub('version', version) ||
-          "http://dist.neo4j.org/neo4j-#{version}-unix.tar.gz"
+        ENV.fetch('NEO4J_DIST', 'http://dist.neo4j.org/neo4j-VERSION-unix.tar.gz').gsub('VERSION', version)
       end
     end
   end

--- a/spec/starnix_server_manager_spec.rb
+++ b/spec/starnix_server_manager_spec.rb
@@ -192,6 +192,21 @@ module Neo4j
             end
           end
         end
+
+        describe '#download_url' do
+          it 'should return default neo4j download url' do
+            ENV['NEO4J_DIST'] = nil
+            expect(server_manager.send(:download_url, 'community-9.9.9'))
+              .to eq('http://dist.neo4j.org/neo4j-community-9.9.9-unix.tar.gz')
+          end
+
+          it 'should return custom neo4j download url' do
+            ENV['NEO4J_DIST'] = 'file://custom-location/neo4j-version-unix.tar.gz'
+            expect(server_manager.send(:download_url, 'community-9.9.9'))
+              .to eq('file://custom-location/neo4j-community-9.9.9-unix.tar.gz')
+            ENV['NEO4J_DIST'] = nil
+          end
+        end
       end
     end
   end

--- a/spec/starnix_server_manager_spec.rb
+++ b/spec/starnix_server_manager_spec.rb
@@ -201,7 +201,7 @@ module Neo4j
           end
 
           it 'should return custom neo4j download url' do
-            ENV['NEO4J_DIST'] = 'file://custom-location/neo4j-version-unix.tar.gz'
+            ENV['NEO4J_DIST'] = 'file://custom-location/neo4j-VERSION-unix.tar.gz'
             expect(server_manager.send(:download_url, 'community-9.9.9'))
               .to eq('file://custom-location/neo4j-community-9.9.9-unix.tar.gz')
             ENV['NEO4J_DIST'] = nil


### PR DESCRIPTION
Fixes #
Allows specifying a custom neo4j download url. Please see private channel on gitter.
This pull introduces/changes:
 * Custom location can be specified via an environment variable.
 * 




Pings:
@cheerfulstoic
@subvertallchris
