### PR TITLE
Increase version

### DIFF
--- a/neo4j_versions.yml
+++ b/neo4j_versions.yml
@@ -1,5 +1,5 @@
 ---
-  stable: &stable '3.4.1'
+  stable: &stable '3.5.6'
   alpha: 3.5.0-alpha04
   milestone: 3.4.1
   rc: &rc 3.4.0-rc02


### PR DESCRIPTION
Fixes # (not sure)

This pull introduces/changes:
 * update so rails neo4j:install[community-latest] installs neo4j version 3.5.6
 
Pings:
@cheerfulstoic
@subvertallchris
