### PR TITLE
ensuring URI vs. Kernel.open call

### DIFF
--- a/lib/neo4j/rake_tasks/download.rb
+++ b/lib/neo4j/rake_tasks/download.rb
@@ -15,7 +15,7 @@ module Neo4j
 
       def fetch(message)
         require 'open-uri'
-        open(@url,
+        URI.parse(@url).open(
              content_length_proc: lambda do |total|
                create_progress_bar(message, total) if total && total > 0
              end,

--- a/lib/neo4j/rake_tasks/server_manager.rb
+++ b/lib/neo4j/rake_tasks/server_manager.rb
@@ -290,7 +290,7 @@ module Neo4j
         require 'open-uri'
         require 'yaml'
 
-        YAML.load(open(NEO4J_VERSIONS_URL).read)
+        YAML.load(URI.parse(NEO4J_VERSIONS_URL).open(&:read))
       end
 
       def download_neo4j(version)


### PR DESCRIPTION
Fixes #
<img width="1785" alt="Screen Shot 2021-05-15 at 4 56 38 PM" src="https://user-images.githubusercontent.com/3923922/118379249-8671d780-b59e-11eb-9098-5dcd3680e3d9.png">


This pull introduces/changes:
 * Ensures open function is from open-uri project vs. Kernel.open


Pings:
@cheerfulstoic
@subvertallchris
