### PR TITLE
Fixes Errno::ENOENT on rake neo4j:install

### DIFF
--- a/lib/neo4j/rake_tasks/download.rb
+++ b/lib/neo4j/rake_tasks/download.rb
@@ -15,7 +15,7 @@ module Neo4j
 
       def fetch(message)
         require 'open-uri'
-        open(@url,
+        URI.open(@url,
              content_length_proc: lambda do |total|
                create_progress_bar(message, total) if total && total > 0
              end,


### PR DESCRIPTION
Fixes #

open was referring to Kernal `open` method instead of `URI.open` causing:

Errno::ENOENT: No such file or directory @ rb_sysopen - http://dist.neo4j.org/neo4j-community-3.0.0-unix.tar.gz

This fixes it.

Pings:
@cheerfulstoic
@subvertallchris
